### PR TITLE
Revert "chore: cache pip dependencies in github actions"

### DIFF
--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.10'
-        cache: 'pip' # caching pip dependencies
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.10'
-        cache: 'pip'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This reverts commit 9154ba92d33fa85b3da91a1539244fab3170722b. Github actions fails as we don't use a requirements file.